### PR TITLE
use XDGBDS for config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -200,5 +200,6 @@ This is especially useful if you want to see how your context files are evaluate
 
 ### Configuration
 
-See _~/houston/config.yml_ file for available configuration options.
-It is automatically created when you run `hu` for the first time.
+See _example-config.yml_ for available configuration options.
+The configuration is automatically created when you run `hu` for the first time.
+It will either be in `$XDG_CONFIG_HOME/houston/config.yml` or `~/.config/houston/config.yml`.

--- a/example-config.yml
+++ b/example-config.yml
@@ -1,0 +1,7 @@
+defaultShell: bash
+defaultContextShell: bash
+defaultRunMode: ask
+openAi:
+  apiKey: null
+  model: gpt-4
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,7 +168,15 @@ fn get_default_shell_for_system() -> String {
 }
 
 pub fn get_houston_dir() -> std::path::PathBuf {
-    dirs::home_dir().unwrap().join(CONFIG_DIR_NAME)
+    // Use the XDG_CONFIG_HOME environment variable if it's set, otherwise fallback to $HOME/.config
+    let xdg_config_home = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir().expect("Home directory not found").join(".config")
+        });
+
+    xdg_config_home.join(CONFIG_DIR_NAME)
 }
 
 /// load user config from the default config file location


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

The config will either be read from `$XDG_CONFIG_HOME/houston/config.yml` or `$HOME/.config/houston/config.yml`

This eliminates unnecessary pollution in the `$HOME` directory and keeps things organized.